### PR TITLE
w in double_consonants causing trouble removed

### DIFF
--- a/lib/verbs.rb
+++ b/lib/verbs.rb
@@ -10,7 +10,7 @@ require 'verbs/improper_construction'
 module Verbs
   CONSONANTS = %w(b c d f g h j k l m n p q r s t v w x z)
   CONSONANT_PATTERN = "[#{CONSONANTS.join}]"
-  DOUBLED_CONSONANTS = %w(b c d f g h j k l m n p q r s t w z)
+  DOUBLED_CONSONANTS = %w(b c d f g h j k l m n p q r s t z)
   DOUBLED_CONSONANT_PATTERN = "[#{DOUBLED_CONSONANTS.join}]"
   VOWELS = %w(a e i o u y)
   VOWEL_PATTERN = "[#{VOWELS.join}]"


### PR DESCRIPTION
- Verbs such as 'swallow', 'follow'  would end being conjugated
  this way : "swalowwing", "followwed".
- Tests are still ok after the deletion
