### PR TITLE
Input immutability

### DIFF
--- a/lib/verbs/conjugator.rb
+++ b/lib/verbs/conjugator.rb
@@ -35,6 +35,8 @@ module Verbs
     end
 
     def conjugate(infinitive, options = {})
+      infinitive = infinitive.dup if infinitive.is_a?(String)
+      
       tense = options[:tense] ||         :present    # present, past, future
       person = options[:person] ||       :third      # first, second, third
       plurality = options[:plurality] || :singular   # singular, plural

--- a/test/test_verbs.rb
+++ b/test/test_verbs.rb
@@ -144,4 +144,10 @@ class TestVerbs < Test::Unit::TestCase
       assert_equal 'changes', standard.conjugate('change')
     end
   end
+
+  def test_immutability
+    verb = 'like'
+    Verbs::Conjugator.conjugate(verb, :tense => :past, :aspect => :perfective)
+    assert_equal 'like', verb
+  end
 end

--- a/verbs.gemspec
+++ b/verbs.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.add_development_dependency 'bueller'
+  s.add_development_dependency 'test-unit'
   s.add_dependency 'activesupport', '>= 2.3.4'
   s.add_dependency 'i18n'
 end


### PR DESCRIPTION
A start for fixing input immutability (#17).

Notes:

 * Added a failing test.
 * Added the `test-unit` gem because it was removed from the standard library in Ruby 2.2+.
 * Tried adding `infinitive = infinitive.to_s.clone` to `Verbs::Conjugator.conjugate`. This caused a lot of test failures. Apparently there is internal code that relies on mutating behavior.
