### PR TITLE
Fix present_participle for "be"

### DIFF
--- a/lib/verbs/conjugator.rb
+++ b/lib/verbs/conjugator.rb
@@ -115,7 +115,7 @@ module Verbs
         present_participle_with_doubled_terminal_consonant_for infinitive
       elsif infinitive.to_s.match(/c$/)
         infinitive.to_s.concat('king').to_sym
-      elsif infinitive.to_s.match(/ye$/) or infinitive.to_s.match(/oe$/) or infinitive.to_s.match(/nge$/) or infinitive.to_s.match(/ee$/)
+      elsif infinitive.to_s.match(/^be$/) or infinitive.to_s.match(/ye$/) or infinitive.to_s.match(/oe$/) or infinitive.to_s.match(/nge$/) or infinitive.to_s.match(/ee$/)
         infinitive.to_s.concat('ing').to_sym
       elsif infinitive.to_s.match(/ie$/)
         infinitive.to_s[0..-2].concat('ying').to_sym

--- a/test/test_verbs.rb
+++ b/test/test_verbs.rb
@@ -12,6 +12,10 @@ class TestVerbs < Test::Unit::TestCase
     assert_equal 'was', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :plurality => :singular, :aspect => :perfective)
     assert_equal 'were', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :first, :plurality => :plural, :aspect => :perfective)
     assert_equal 'were', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :plurality => :plural, :aspect => :perfective)
+
+    assert_equal 'was being', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :aspect => :progressive)
+    assert_equal 'is being', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :third,  :aspect => :progressive)
+    assert_equal 'will be being', Verbs::Conjugator.conjugate(:be, :tense => :future, :person => :third, :aspect => :progressive)
   end
   def test_irregular_conjugation
     assert_equal 'break', Verbs::Conjugator.conjugate(:break, :tense => :present, :person => :first, :plurality => :singular, :aspect => :habitual)


### PR DESCRIPTION
I put the fix in the present_participle logic.  Perhaps it would be a better fit in the irregular conjugation list, but the present_participle function does not look there for anything.