### PR TITLE
Fix past habitual.  Change usually -> used to + infinitive

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,7 +47,7 @@ Set this to a string to prepend the conjugated verb with it. When set to <tt>tru
 
   EXAMPLE                   TENSE    ASPECT
   
-  I usually accepted        past     habitual
+  I used to accept          past     habitual
   I had accepted            past     perfect
   I accepted                past     perfective
   I was accepting           past     progressive

--- a/lib/verbs/conjugator.rb
+++ b/lib/verbs/conjugator.rb
@@ -199,7 +199,7 @@ module Verbs
         form.concat ['be', :present_participle] if aspect == :progressive
         form.concat ['be about to', :infinitive] if aspect == :prospective
       else
-        form.concat ['usually', :past_participle] if [tense, aspect] == [:past, :habitual]
+        form.concat ['used to', :infinitive] if [tense, aspect] == [:past, :habitual]
         form.concat [:have, :past_participle] if aspect == :perfect
         form << :past if [tense, aspect] == [:past, :perfective]
         form.concat [:be, :present_participle] if aspect == :progressive

--- a/test/test_verbs.rb
+++ b/test/test_verbs.rb
@@ -2,11 +2,20 @@ require 'helper'
 
 class TestVerbs < Test::Unit::TestCase
   def test_copular_conjugation
+    # present habitual
     assert_equal 'am', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :first, :plurality => :singular, :aspect => :habitual)
     assert_equal 'are', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :second, :plurality => :singular, :aspect => :habitual)
     assert_equal 'is', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :third, :plurality => :singular, :aspect => :habitual)
     assert_equal 'are', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :first, :plurality => :plural, :aspect => :habitual)
     assert_equal 'are', Verbs::Conjugator.conjugate(:be, :tense => :present, :person => :third, :plurality => :plural, :aspect => :habitual)
+
+    # past habitual
+    assert_equal 'used to be', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :first, :plurality => :singular, :aspect => :habitual)
+    assert_equal 'used to be', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :second, :plurality => :singular, :aspect => :habitual)
+    assert_equal 'used to be', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :plurality => :singular, :aspect => :habitual)
+    assert_equal 'used to be', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :first, :plurality => :plural, :aspect => :habitual)
+    assert_equal 'used to be', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :plurality => :plural, :aspect => :habitual)
+
     assert_equal 'was', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :first, :plurality => :singular, :aspect => :perfective)
     assert_equal 'were', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :second, :plurality => :singular, :aspect => :perfective)
     assert_equal 'was', Verbs::Conjugator.conjugate(:be, :tense => :past, :person => :third, :plurality => :singular, :aspect => :perfective)
@@ -97,7 +106,7 @@ class TestVerbs < Test::Unit::TestCase
   end
   def test_aspects
     Verbs::Conjugator.with_options :person => :first, :plurality => :singular, :subject => true do |standard|
-      assert_equal 'I usually accepted',        standard.conjugate(:accept, :tense => :past, :aspect => :habitual)
+      assert_equal 'I used to accept',        standard.conjugate(:accept, :tense => :past, :aspect => :habitual)
       assert_equal 'I had accepted',            standard.conjugate(:accept, :tense => :past, :aspect => :perfect)
       assert_equal 'I accepted',                standard.conjugate(:accept, :tense => :past, :aspect => :perfective)
       assert_equal 'I was accepting',           standard.conjugate(:accept, :tense => :past, :aspect => :progressive)


### PR DESCRIPTION
"Usually" could have been fixed instead, but using "used to" with infinitive avoids some word order issues.