### PR TITLE
Fix second person plural

### DIFF
--- a/lib/verbs/conjugations.rb
+++ b/lib/verbs/conjugations.rb
@@ -4,11 +4,13 @@ Verbs::Conjugator.conjugations do |conjugate|
     verb.form :am,    :tense => :present, :person => :first,  :plurality => :singular
     verb.form :is,    :tense => :present, :person => :third,  :plurality => :singular
     verb.form :are,   :tense => :present, :person => :second, :plurality => :singular
+    verb.form :are,   :tense => :present, :person => :second, :plurality => :plural
     verb.form :are,   :tense => :present, :person => :first,  :plurality => :plural
     verb.form :are,   :tense => :present, :person => :third,  :plurality => :plural
     verb.form :was,   :tense => :past,    :person => :first,  :plurality => :singular
     verb.form :was,   :tense => :past,    :person => :third,  :plurality => :singular
     verb.form :were,  :tense => :past,    :person => :second, :plurality => :singular
+    verb.form :were,  :tense => :past,    :person => :second, :plurality => :plural
     verb.form :were,  :tense => :past,    :person => :first,  :plurality => :plural
     verb.form :were,  :tense => :past,    :person => :third,  :plurality => :plural
     verb.form :were,  :tense => :past,    :mood => :subjunctive
@@ -21,11 +23,13 @@ Verbs::Conjugator.conjugations do |conjugate|
     verb.form :have,   :tense => :present, :person => :first,  :plurality => :singular
     verb.form :has,    :tense => :present, :person => :third,  :plurality => :singular
     verb.form :have,   :tense => :present, :person => :second, :plurality => :singular
+    verb.form :have,   :tense => :present, :person => :second, :plurality => :plural
     verb.form :have,   :tense => :present, :person => :first,  :plurality => :plural
     verb.form :have,   :tense => :present, :person => :third,  :plurality => :plural
     verb.form :had,    :tense => :past,    :person => :first,  :plurality => :singular
     verb.form :had,    :tense => :past,    :person => :third,  :plurality => :singular
     verb.form :had,    :tense => :past,    :person => :second, :plurality => :singular
+    verb.form :had,    :tense => :past,    :person => :second, :plurality => :plural
     verb.form :had,    :tense => :past,    :person => :first,  :plurality => :plural
     verb.form :had,    :tense => :past,    :person => :third,  :plurality => :plural
     verb.form :having, :tense => :present, :derivative => :participle

--- a/test/test_verbs.rb
+++ b/test/test_verbs.rb
@@ -150,4 +150,13 @@ class TestVerbs < Test::Unit::TestCase
     Verbs::Conjugator.conjugate(verb, :tense => :past, :aspect => :perfective)
     assert_equal 'like', verb
   end
+
+  def test_second_person_plural_forms
+    Verbs::Conjugator.with_options :person => :second, :plurality => :plural, :subject => true do |standard|
+      assert_equal 'You had accepted',            standard.conjugate(:accept, :tense => :past, :aspect => :perfect)
+      assert_equal 'You accepted',                standard.conjugate(:accept, :tense => :past, :aspect => :perfective)
+      assert_equal 'You were accepting',           standard.conjugate(:accept, :tense => :past, :aspect => :progressive)
+      assert_equal 'You were about to accept',     standard.conjugate(:accept, :tense => :past, :aspect => :prospective)
+    end
+  end
 end


### PR DESCRIPTION
Adds plural forms for second person "to be" and "to have"